### PR TITLE
LIB_DIR getting overwritten

### DIFF
--- a/kp
+++ b/kp
@@ -81,7 +81,7 @@ done
 #
 
 [ -z ${LIB_DIR} ]     && LIB_DIR="/usr/share/lib/kp/lib"
-[ -z ${CONF_DIR} ]    && LIB_DIR="/usr/share/lib/kp/conf"
+[ -z ${CONF_DIR} ]    && CONF_DIR="/usr/share/lib/kp/conf"
 [ -z ${WORKING_DIR} ] && WORKING_DIR="/var/lib/kp"
 [ -z ${RELEASE_DIR} ] && RELEASE_DIR="/tmp"
 [ -z ${LOG_DIR} ]     && LOG_DIR="/usr/share/lib/kp/log"


### PR DESCRIPTION
If CONF_DIR was unset LIB_DIR would get overwritten.
Change this so that CONF_DIR is set instead.