### PR TITLE
Fix typo in license headers

### DIFF
--- a/kp
+++ b/kp
@@ -3,7 +3,7 @@
 # Copyright 2012-2013 "Korora Project" <dev@kororaproject.org>
 #
 # This program is free software: you can redistribute it and/or modify
-# it under the temms of the GNU General Public License as published by
+# it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #

--- a/lib/kp_build
+++ b/lib/kp_build
@@ -3,7 +3,7 @@
 # Copyright 2012-2014 "Korora Project" <dev@kororaproject.org>
 #
 # This program is free software: you can redistribute it and/or modify
-# it under the temms of the GNU General Public License as published by
+# it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #

--- a/lib/kp_buildhelper
+++ b/lib/kp_buildhelper
@@ -3,7 +3,7 @@
 # Copyright 2012-2014 "Korora Project" <dev@kororaproject.org>
 #
 # This program is free software: you can redistribute it and/or modify
-# it under the temms of the GNU General Public License as published by
+# it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #

--- a/lib/kp_checkout
+++ b/lib/kp_checkout
@@ -3,7 +3,7 @@
 # Copyright 2012-2014 "Korora Project" <dev@kororaproject.org>
 #
 # This program is free software: you can redistribute it and/or modify
-# it under the temms of the GNU General Public License as published by
+# it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #

--- a/lib/kp_core
+++ b/lib/kp_core
@@ -3,7 +3,7 @@
 # Copyright 2012-2014 "Korora Project" <dev@kororaproject.org>
 #
 # This program is free software: you can redistribute it and/or modify
-# it under the temms of the GNU General Public License as published by
+# it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #

--- a/lib/kp_help
+++ b/lib/kp_help
@@ -3,7 +3,7 @@
 # Copyright 2012-2014 "Korora Project" <dev@kororaproject.org>
 #
 # This program is free software: you can redistribute it and/or modify
-# it under the temms of the GNU General Public License as published by
+# it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #

--- a/lib/kp_init
+++ b/lib/kp_init
@@ -3,7 +3,7 @@
 # Copyright 2012-2014 "Korora Project" <dev@kororaproject.org>
 #
 # This program is free software: you can redistribute it and/or modify
-# it under the temms of the GNU General Public License as published by
+# it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #

--- a/lib/kp_list
+++ b/lib/kp_list
@@ -3,7 +3,7 @@
 # Copyright 2012-2014 "Korora Project" <dev@kororaproject.org>
 #
 # This program is free software: you can redistribute it and/or modify
-# it under the temms of the GNU General Public License as published by
+# it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #

--- a/lib/kp_release
+++ b/lib/kp_release
@@ -3,7 +3,7 @@
 # Copyright 2012-2014 "Korora Project" <dev@kororaproject.org>
 #
 # This program is free software: you can redistribute it and/or modify
-# it under the temms of the GNU General Public License as published by
+# it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #

--- a/lib/kp_repository
+++ b/lib/kp_repository
@@ -3,7 +3,7 @@
 # Copyright 2012-2014 "Korora Project" <dev@kororaproject.org>
 #
 # This program is free software: you can redistribute it and/or modify
-# it under the temms of the GNU General Public License as published by
+# it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #

--- a/lib/kp_sync
+++ b/lib/kp_sync
@@ -3,7 +3,7 @@
 # Copyright 2012-2014 "Korora Project" <dev@kororaproject.org>
 #
 # This program is free software: you can redistribute it and/or modify
-# it under the temms of the GNU General Public License as published by
+# it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #

--- a/lib/kp_upstream
+++ b/lib/kp_upstream
@@ -3,7 +3,7 @@
 # Copyright 2012-2014 "Korora Project" <dev@kororaproject.org>
 #
 # This program is free software: you can redistribute it and/or modify
-# it under the temms of the GNU General Public License as published by
+# it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #


### PR DESCRIPTION
"temms" fixed to "terms"
Scripts are now correctly identified as "GPL (v3 or later)" by licensecheck